### PR TITLE
Add a bower installation guide

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -299,6 +299,10 @@ To install the SDK, follow the online instructions posted at Github:
 
 [https://github.com/ringcentral/js-sdk#installation](https://github.com/ringcentral/js-sdk#installation)
 
+~~~ javascript
+bower install ringcentral --save
+~~~
+
 ## Instantiating the SDK
 
 ~~~ javascript


### PR DESCRIPTION
Provide a straight-forward way for developers who just want to try the tutorial. 
